### PR TITLE
Update working link for Kafka hompage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kafka-php
-kafka-php allows you to produce messages to the [Apache Kafka](http://incubator.apache.org/kafka/) distributed publish/subscribe messaging service.
+kafka-php allows you to produce messages to the [Apache Kafka](http://kafka.apache.org/) distributed publish/subscribe messaging service.
 
 ## Requirements
 


### PR DESCRIPTION
Current link was dead, so updated to the working link.