### PR TITLE
🔎 Fix infinite loop when fwrite returns 0 due to Broken pipe

### DIFF
--- a/src/lib/Kafka/Socket.php
+++ b/src/lib/Kafka/Socket.php
@@ -275,10 +275,10 @@ class Kafka_Socket
 			if (false !== $writable) {
 				$res = stream_get_meta_data($this->stream);
 				if (!empty($res['timed_out'])) {
-					throw new Kafka_Exception_Socket_Timeout('Timed out writing ' . strlen($buf) . ' bytes to stream after writing ' . $written . ' bytes');
+					throw new Kafka_Exception_Socket_Timeout('Timed out writing ' . $buflen . ' bytes to stream after writing ' . $written . ' bytes');
 				}
 			}
-			throw new Kafka_Exception_Socket('Could not write ' . strlen($buf) . ' bytes to stream');
+			throw new Kafka_Exception_Socket('Could not write ' . $buflen . ' bytes to stream');
 		}
 		return $written;
 	}

--- a/src/lib/Kafka/Socket.php
+++ b/src/lib/Kafka/Socket.php
@@ -75,7 +75,7 @@ class Kafka_Socket
 	/**
 	 * Socket port
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	private $port = -1;
 
@@ -83,11 +83,11 @@ class Kafka_Socket
 	 * Constructor
 	 *
 	 * @param string  $host            Host
-	 * @param integer $port            Port
-	 * @param integer $recvTimeoutSec  Recv timeout in seconds
-	 * @param integer $recvTimeoutUsec Recv timeout in microseconds
-	 * @param integer $sendTimeoutSec  Send timeout in seconds
-	 * @param integer $sendTimeoutUsec Send timeout in microseconds
+	 * @param int $port            Port
+	 * @param int $recvTimeoutSec  Recv timeout in seconds
+	 * @param int $recvTimeoutUsec Recv timeout in microseconds
+	 * @param int $sendTimeoutSec  Send timeout in seconds
+	 * @param int $sendTimeoutUsec Send timeout in microseconds
 	 */
 	public function __construct($host, $port, $recvTimeoutSec = 0, $recvTimeoutUsec = 750000, $sendTimeoutSec = 0, $sendTimeoutUsec = 100000) {
 		$this->host            = $host;
@@ -103,7 +103,7 @@ class Kafka_Socket
 	 *
 	 * @param resource $stream File handle
 	 *
-	 * @return void
+	 * @return Kafka_Socket
 	 */
 	static public function createFromStream($stream) {
 		$socket = new self('localhost', 0);
@@ -125,7 +125,7 @@ class Kafka_Socket
 	/**
 	 * Connects the socket
 	 *
-	 * @return void
+	 * @return bool|null
 	 * @throws Kafka_Exception_Socket_Connection
 	 */
 	public function connect() {
@@ -178,8 +178,8 @@ class Kafka_Socket
 	 * This method will not wait for all the requested data, it will return as
 	 * soon as any data is received.
 	 *
-	 * @param integer $len               Maximum number of bytes to read.
-	 * @param boolean $verifyExactLength Throw an exception if the number of read bytes is less than $len
+	 * @param int $len               Maximum number of bytes to read.
+	 * @param bool $verifyExactLength Throw an exception if the number of read bytes is less than $len
 	 *
 	 * @return string Binary data
 	 * @throws Kafka_Exception_Socket
@@ -237,7 +237,7 @@ class Kafka_Socket
 	 *
 	 * @param string $buf The data to write
 	 *
-	 * @return integer
+	 * @return int
 	 * @throws Kafka_Exception_Socket
 	 */
 	public function write($buf) {

--- a/src/lib/Kafka/Socket.php
+++ b/src/lib/Kafka/Socket.php
@@ -254,11 +254,12 @@ class Kafka_Socket
 			if ($writable > 0) {
 				// Set a temporary error handler to watch for Broken pipes
 				set_error_handler(function ($type, $msg, $file, $line) use ($buflen, &$written) {
-					if ($type === E_NOTICE && strpos($msg, 'Broken pipe') !== false) {
+					if (strpos($msg, 'Broken pipe') !== false) {
 						throw new \Kafka_Exception_Socket(
 							sprintf('Connection broken while writing %d bytes to stream, completed writing only %d bytes', $buflen, $written)
 						);
 					}
+					return false; // Allow normal error handling to continue
 				});
 				try {
 					// write remaining buffer bytes to stream


### PR DESCRIPTION
We have a case were in some cases, the `fwrite` may raise an E_NOTICE such as `fwrite(): send of 3115 bytes failed with errno=32 Broken pipe` and then return the integer `0`, which won't be detected as a failure in `Socket.php`, and thus will continue the infinite loop trying to write forever. It's worth mentioning that in such a case, `stream_select` _does_ return a value such that `$writable > 0` even though we're in a bad state.

There are a few possible fixes for this, this PR is one, where we set a temporary error handler callback to detect the broken pipe, and throw an exception if it happens. Otherwise normal error handling will proceed so we should not affect any other scenarios.